### PR TITLE
backstep end position to avoid duplicating last line when cursor at start of line

### DIFF
--- a/src/main/java/ir/mmd/intellijDev/Actionable/duplicate/DuplicateAction.kt
+++ b/src/main/java/ir/mmd/intellijDev/Actionable/duplicate/DuplicateAction.kt
@@ -75,7 +75,7 @@ abstract class DuplicateAction : MultiCaretAction(), DumbAware {
 		
 		if (start != end) /* has selection */ {
 			startingLine = document.getLineNumber(start)
-			endingLine = document.getLineNumber(end)
+			endingLine = document.getLineNumber(end - 1)
 			startOffset = document.getLineStartOffset(startingLine)
 			endOffset = document.getLineEndOffset(endingLine)
 		} else /* no selection */ {

--- a/src/main/java/ir/mmd/intellijDev/Actionable/duplicate/DuplicateAction.kt
+++ b/src/main/java/ir/mmd/intellijDev/Actionable/duplicate/DuplicateAction.kt
@@ -25,8 +25,8 @@ abstract class DuplicateAction : MultiCaretAction(), DumbAware {
 		end: Int
 	) = with(getDuplicateString(start, end)) {
 		runWriteCommandAction {
-		    // Reset caret position and selection after inserting text.
-		    val caretOffset = editor.caretModel.offset
+			// Reset caret position and selection after inserting text.
+			val caretOffset = editor.caretModel.offset
 			document.insertString(endOffset, "\n${text}")
 			editor.caretModel.currentCaret.setSelection(start, end)
 			editor.caretModel.moveToOffset(caretOffset)
@@ -43,7 +43,7 @@ abstract class DuplicateAction : MultiCaretAction(), DumbAware {
 	) = with(getDuplicateString(start, end)) {
 		runWriteCommandAction {
 			// Reset caret position and selection after inserting text.
-		    val caretOffset = editor.caretModel.offset
+			val caretOffset = editor.caretModel.offset
 			document.insertString(startOffset, "${text}\n")
 			val insertLength = text.length + 1
 			editor.caretModel.currentCaret.setSelection(start + insertLength, end + insertLength)


### PR DESCRIPTION
Move end position back one character to avoid last line being duplicated when the end cursor/selection position is at the start of the line.

This is to address issue 105.